### PR TITLE
[NX036] manifests para productservice

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,18 @@
+# Manifiestos Kubernetes — productservice
+
+Generados automáticamente por **NX036 Platform**.
+
+**Tipo detectado**: Java Spring Boot (Maven)
+**Puerto sugerido**: 8080
+
+## Importante
+
+El `Deployment` lleva la imagen `ghcr.io/REPLACE/IMAGE:tag` como **placeholder**.
+Tu CI/CD debe sustituirla por la imagen real que publica al registry:
+
+```bash
+# Ejemplo en GitHub Actions:
+sed -i "s|ghcr.io/REPLACE/IMAGE:tag|ghcr.io/${{ github.repository }}:${{ github.sha }}|g" k8s/deployment.yaml
+```
+
+Argo CD sincronizará automáticamente los cambios cuando el commit llegue al branch.

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: productservice
+  namespace: develop
+  labels:
+    app: productservice
+    nx036.io/managed: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: productservice
+  template:
+    metadata:
+      labels:
+        app: productservice
+    spec:
+      containers:
+        - name: productservice
+          image: ghcr.io/REPLACE/IMAGE:tag
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet: { path: /actuator/health, port: 8080 }
+            initialDelaySeconds: 20
+          livenessProbe:
+            httpGet: { path: /actuator/health, port: 8080 }
+            initialDelaySeconds: 40
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 100m
+            limits:
+              memory: 512Mi
+              cpu: 500m

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: productservice
+  namespace: develop
+  labels:
+    app: productservice
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - productservice.nx036.com
+      secretName: wildcard-nx036-com-tls
+  rules:
+    - host: productservice.nx036.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: productservice
+                port:
+                  number: 80

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: productservice
+  namespace: develop
+  labels:
+    app: productservice
+spec:
+  type: ClusterIP
+  selector:
+    app: productservice
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+      protocol: TCP

--- a/tekton/pipeline.yaml
+++ b/tekton/pipeline.yaml
@@ -1,0 +1,46 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: productservice-build
+  namespace: develop
+spec:
+  params:
+    - { name: repo-url,   type: string }
+    - { name: revision,   type: string, default: main }
+    - { name: image-url,  type: string, description: "<registry>/<owner>/<repo>" }
+    - { name: image-tag,  type: string, default: latest }
+    - { name: dockerfile, type: string, default: "Dockerfile" }
+  workspaces:
+    - { name: source }
+    - { name: docker-credentials, description: "Secret tipo kubernetes.io/dockerconfigjson con creds del registry" }
+  tasks:
+    - name: clone
+      taskRef: { name: git-clone, kind: ClusterTask }
+      workspaces:
+        - { name: output, workspace: source }
+      params:
+        - { name: url,      value: $(params.repo-url) }
+        - { name: revision, value: $(params.revision) }
+    - name: build-and-push
+      runAfter: [clone]
+      taskRef: { name: kaniko, kind: ClusterTask }
+      workspaces:
+        - { name: source, workspace: source }
+        - { name: dockerconfig, workspace: docker-credentials }
+      params:
+        - { name: IMAGE,      value: $(params.image-url):$(params.image-tag) }
+        - { name: DOCKERFILE, value: $(params.dockerfile) }
+        - { name: CONTEXT,    value: . }
+    - name: update-deployment
+      runAfter: [build-and-push]
+      taskSpec:
+        params:
+          - { name: image, type: string }
+        steps:
+          - name: patch
+            image: bitnami/kubectl:latest
+            script: |
+              #!/bin/sh
+              kubectl -n develop set image deployment/productservice productservice=$(params.image)
+      params:
+        - { name: image, value: $(params.image-url):$(params.image-tag) }

--- a/tekton/pipelinerun-template.yaml
+++ b/tekton/pipelinerun-template.yaml
@@ -1,0 +1,20 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: productservice-build-
+  namespace: develop
+spec:
+  pipelineRef: { name: productservice-build }
+  params:
+    - { name: repo-url,  value: "https://github.com/REPLACE/REPLACE.git" }
+    - { name: revision,  value: "main" }
+    - { name: image-url, value: "ghcr.io/REPLACE/REPLACE" }
+    - { name: image-tag, value: "latest" }
+  workspaces:
+    - name: source
+      volumeClaimTemplate:
+        spec:
+          accessModes: [ReadWriteOnce]
+          resources: { requests: { storage: 1Gi } }
+    - name: docker-credentials
+      secret: { secretName: nx036-registry-creds }


### PR DESCRIPTION
Generado por **NX036 Platform**.

**Tipo detectado**: Java Spring Boot (Maven)
**Puerto**: 8080
**Imagen placeholder**: `ghcr.io/REPLACE/IMAGE:tag` — sustituir en tu CI/CD.

Tras hacer merge de este PR, Argo CD sincronizará automáticamente y desplegará la aplicación en el namespace `develop`.

Si tienes Tekton instalado en el cluster, el archivo `tekton/pipeline.yaml` definirá un build con Kaniko que se puede disparar manualmente o vía webhook.